### PR TITLE
修复泛解析问题

### DIFF
--- a/tencentcloud_ddns/Makefile
+++ b/tencentcloud_ddns/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-tencentddns
 PKG_VERSION:=0.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE

--- a/tencentcloud_ddns/root/usr/sbin/tencentddns
+++ b/tencentcloud_ddns/root/usr/sbin/tencentddns
@@ -3,20 +3,15 @@
 NAME=tencentddns
 log_file=/var/log/$NAME.log
 
-uci_get_by_name() {
-	local ret=$(uci get $NAME.$1.$2 2>/dev/null)
-	echo ${ret:=$3}
-}
-
 uci_bool_by_name() {
-	case "$(uci_get_by_name $1 $2)" in
+	case "$(uci get $NAME.$1.$2 2>/dev/null)" in
 		1|on|true|yes|enabled) return 0;;
 	esac
 	return 1
 }
 
 intelnetip() {
-	tmp_ip=`curl -sL --connect-timeout 3   ns1.dnspod.net:6666`
+	tmp_ip=`curl -sL --connect-timeout 3 ns1.dnspod.net:6666`
 	if [ "Z$tmp_ip" == "Z" ]; then
 		tmp_ip=`curl -sL --connect-timeout 3 members.3322.org/dyndns/getip`
 	fi
@@ -32,7 +27,7 @@ intelnetip() {
 resolve2ip() {
 	# resolve2ip domain<string>
 	domain=$1
-	tmp_ip=`nslookup    $domain f1g1ns1.dnspod.net 2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -n1`
+	tmp_ip=`nslookup $domain f1g1ns1.dnspod.net 2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -n1`
 	if [ "Z$tmp_ip" == "Z" ]; then
 		tmp_ip=`nslookup $domain f1g1ns2.dnspod.net  2>/dev/null | sed '/^Server/d; /#53$/d' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | tail -n1`
 	fi
@@ -84,7 +79,6 @@ send_request() {
 get_recordid() {
         sed 's/"records"/\n/g' | sed -n '2p' | sed 's/ttl/\n/g' | sed -n 's/.*"id[^0-9]*\([0-9]*\).*/\1\n/p' | sort -ru | sed /^$/d
 }
-
 
 get_recordid2() {
         sed 's/"record"/\n/g' | sed -n '2p' |  sed -n 's/.*"id[^0-9]*\([0-9]*\).*/\1\n/p' | sort -ru | sed /^$/d
@@ -146,13 +140,13 @@ clean_log() {
 [ -x /usr/bin/openssl -a -x /usr/bin/curl -a -x /bin/sed ] ||
 	( echo "Need [ openssl + curl + sed ]" && exit 1 )
 
-ak_id=$(uci_get_by_name   base key_id)
-ak_token=$(uci_get_by_name  base key_token)
-rrid=$(uci_get_by_name    base record_id)
-main_dm=$(uci_get_by_name base main_domain)
-sub_dm=$(uci_get_by_name  base sub_domain)
+ak_id=$(uci get $NAME.base.key_id 2>/dev/null)
+ak_token=$(uci get $NAME.base.key_token 2>/dev/null)
+rrid=$(uci get $NAME.base.record_id 2>/dev/null)
+main_dm=$(uci get $NAME.base.main_domain 2>/dev/null)
+sub_dm=$(uci get $NAME.base.sub_domain 2>/dev/null)
 
-iface=$(uci_get_by_name   base interface)
+iface=$(uci get $NAME.base.interface 2>/dev/null)
 if [ "Z$iface" == "Zinternet" -o "Z$iface" == "Z" ]; then
 	ip=$(intelnetip)
 else


### PR DESCRIPTION
修复因为使用*泛解析导致初始启动时参数获取错误导致报错的问题, 虽然过一会程序重新执行几次会自动恢复正常